### PR TITLE
fix: update request path to widnet provider in tests

### DIFF
--- a/test/unit/cep-promise-browser.spec.js
+++ b/test/unit/cep-promise-browser.spec.js
@@ -36,8 +36,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -151,8 +151,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -187,8 +187,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -223,8 +223,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -259,8 +259,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -294,8 +294,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -329,8 +329,8 @@ describe('[unit] cep-promise for browser', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/99999999.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/99999-999.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -391,8 +391,8 @@ describe('[unit] cep-promise for browser', () => {
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
       nock('https://brasilapi.com.br/')

--- a/test/unit/cep-promise-node.spec.js
+++ b/test/unit/cep-promise-node.spec.js
@@ -48,8 +48,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -177,8 +177,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -227,8 +227,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -278,7 +278,7 @@ describe('[unit] cep-promise for node', () => {
         )
 
       nock('https://cep.widenet.host')
-        .get('/busca-cep/api/cep/05010000.json')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -328,8 +328,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -379,8 +379,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -429,8 +429,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -478,8 +478,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -527,8 +527,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -575,8 +575,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -624,8 +624,8 @@ describe('[unit] cep-promise for node', () => {
           path.join(__dirname, '/fixtures/viacep-cep-99999999-error.json')
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/99999999.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/99999-999.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-99999999-error.json')
@@ -704,8 +704,8 @@ describe('[unit] cep-promise for node', () => {
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
       nock('https://brasilapi.com.br/')
@@ -764,8 +764,8 @@ describe('[unit] cep-promise for node', () => {
         .get('/ws/05010000/json/')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .reply(400, '<h2>Bad Request (400)</h2>')
 
       nock('https://brasilapi.com.br/')
@@ -825,8 +825,8 @@ describe('[unit] cep-promise for node', () => {
           'getaddrinfo ENOTFOUND apps.correios.com.br apps.correios.com.br:443'
         )
 
-      nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithError(
           'getaddrinfo ENOTFOUND apps.correios.com.br apps.correios.com.br:443'
         )

--- a/test/unit/cep-promise-providers.spec.js
+++ b/test/unit/cep-promise-providers.spec.js
@@ -143,8 +143,8 @@ describe('when invoked with providers parameter', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      const wideNetMock = nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      const wideNetMock = nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -192,8 +192,8 @@ describe('when invoked with providers parameter', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      const wideNetMock = nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      const wideNetMock = nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -241,8 +241,8 @@ describe('when invoked with providers parameter', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      const wideNetMock = nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      const wideNetMock = nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -291,7 +291,7 @@ describe('when invoked with providers parameter', () => {
         )
 
       const wideNetMock = nock('https://cep.widenet.host')
-        .get('/busca-cep/api/cep/05010000.json')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -339,8 +339,8 @@ describe('when invoked with providers parameter', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      const wideNetMock = nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      const wideNetMock = nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -396,8 +396,8 @@ describe('when invoked with providers parameter', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      const wideNetMock = nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      const wideNetMock = nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')
@@ -445,8 +445,8 @@ describe('when invoked with providers parameter', () => {
           path.join(__dirname, '/fixtures/viacep-cep-05010000-found.json')
         )
 
-      const wideNetMock = nock('https://ws.apicep.com')
-        .get('/busca-cep/api/cep/05010000.json')
+      const wideNetMock = nock('https://cdn.apicep.com')
+        .get('/file/apicep/05010-000.json')
         .replyWithFile(
           200,
           path.join(__dirname, '/fixtures/widenet-cep-05010000-found.json')


### PR DESCRIPTION
Correção dos testes feita com intenção de dar vazão ao https://github.com/BrasilAPI/cep-promise/pull/248

Aguardo sua aprovação @rafas para levarmos essa alteração para uma release.